### PR TITLE
Session client and not admin

### DIFF
--- a/src/app/(auth)/auth/invite/route.ts
+++ b/src/app/(auth)/auth/invite/route.ts
@@ -11,7 +11,7 @@ export async function GET(request: NextRequest) {
   const membershipId = request.nextUrl.searchParams.get("membershipId");
   const teamId = request.nextUrl.searchParams.get("teamId");
 
-  const { account, users, teams } = await createAdminClient();
+  const { account, teams } = await createSessionClient();
 
   const acceptedInvitation = await teams.updateMembershipStatus(
     teamId,


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Fixed the client creation in the invite route by replacing `createAdminClient` with `createSessionClient`.
- Removed unnecessary `users` variable from the destructured object, aligning with the new client usage.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Fix client creation by using session client instead of admin client</code></dd></summary>
<hr>

src/app/(auth)/auth/invite/route.ts

<li>Replaced <code>createAdminClient</code> with <code>createSessionClient</code>.<br> <li> Removed <code>users</code> from the destructured object.<br>


</details>


  </td>
  <td><a href="https://github.com/biso-no/bisov3/pull/28/files#diff-e2f23c17163669a48fd2958f8862d6a74fa31b73f9dcd119661571fc818b145e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information